### PR TITLE
Removing throttling policy as a workaround to an issue with SNS

### DIFF
--- a/module.yml
+++ b/module.yml
@@ -117,8 +117,6 @@ Resources:
           numRetries: 100
           numNoDelayRetries: 0
           backoffFunction: exponential
-        throttlePolicy:
-          maxReceivesPerSecond: 1
       Endpoint: !Ref HttpEndpoint
       Protocol: http
       TopicArn: !Ref Topic
@@ -133,8 +131,6 @@ Resources:
           numRetries: 100
           numNoDelayRetries: 0
           backoffFunction: exponential
-        throttlePolicy:
-          maxReceivesPerSecond: 1
       Endpoint: !Ref HttpsEndpoint
       Protocol: https
       TopicArn: !Ref Topic
@@ -149,7 +145,7 @@ Outputs:
   ModuleId:
     Value: 'alerting'
   ModuleVersion:
-    Value: '1.2.0'
+    Value: '1.3.0'
   StackName:
     Value: !Ref 'AWS::StackName'
   Arn:

--- a/module.yml
+++ b/module.yml
@@ -145,7 +145,7 @@ Outputs:
   ModuleId:
     Value: 'alerting'
   ModuleVersion:
-    Value: '1.3.0'
+    Value: '1.2.1'
   StackName:
     Value: !Ref 'AWS::StackName'
   Arn:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cfn-modules/alerting",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Central SNS topic that receives alerts from other modules and forwards them to your team via email, HTTP, or HTTPS",
   "author": "Michael Wittig <michael@widdix.de>",
   "license": "Apache-2.0",


### PR DESCRIPTION
See https://cloudonaut.io/loosing-trust-in-aws-sns-broken-for-24-days/ for details