### PR TITLE
Revert SNS workaround after bus is fixed by AWS

### DIFF
--- a/module.yml
+++ b/module.yml
@@ -117,6 +117,8 @@ Resources:
           numRetries: 100
           numNoDelayRetries: 0
           backoffFunction: exponential
+        throttlePolicy:
+          maxReceivesPerSecond: 1
       Endpoint: !Ref HttpEndpoint
       Protocol: http
       TopicArn: !Ref Topic
@@ -131,6 +133,8 @@ Resources:
           numRetries: 100
           numNoDelayRetries: 0
           backoffFunction: exponential
+        throttlePolicy:
+          maxReceivesPerSecond: 1
       Endpoint: !Ref HttpsEndpoint
       Protocol: https
       TopicArn: !Ref Topic
@@ -145,7 +149,7 @@ Outputs:
   ModuleId:
     Value: 'alerting'
   ModuleVersion:
-    Value: '1.2.1'
+    Value: '1.2.2'
   StackName:
     Value: !Ref 'AWS::StackName'
   Arn:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cfn-modules/alerting",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Central SNS topic that receives alerts from other modules and forwards them to your team via email, HTTP, or HTTPS",
   "author": "Michael Wittig <michael@widdix.de>",
   "license": "Apache-2.0",


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
